### PR TITLE
[코드 수정] 로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     //implementation 'redis.clients:jedis:3.6.3' // RedisSubscriber
-    implementation 'org.springframework.boot:spring-boot-starter-reactor-netty'//broker
+    //implementation 'org.springframework.boot:spring-boot-starter-reactor-netty'//broker
     //implementation 'org.springframework.session:spring-session-data-redis'
 
     // 메시지 큐

--- a/src/main/java/com/dalcho/adme/config/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/dalcho/adme/config/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,16 @@
+package com.dalcho.adme.config.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+public class CustomAccessDeniedHandler implements AccessDeniedHandler { // 권한
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException exception)throws IOException{
+        //response.sendError(HttpServletResponse.SC_FORBIDDEN, "Access is denied");
+        response.sendRedirect("/error");
+    }
+}

--- a/src/main/java/com/dalcho/adme/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/dalcho/adme/config/security/CustomAuthenticationEntryPoint.java
@@ -30,9 +30,8 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     }
 
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
         log.info("[ commence ] : " + "인증 실패");
-        //sendErrorResponse(response, "인증 실패");
-        //response.sendRedirect("/user/login");
+        response.sendRedirect("/user/login");
     }
 }

--- a/src/main/java/com/dalcho/adme/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/dalcho/adme/config/security/CustomAuthenticationEntryPoint.java
@@ -1,7 +1,6 @@
 package com.dalcho.adme.config.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +31,12 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
         log.info("[ commence ] : " + "인증 실패");
-        response.sendRedirect("/user/login");
+        String acceptHeader = request.getHeader("Accept");
+        if(acceptHeader.contains("text/html")){
+            log.info("[ html ]");
+            //response.sendRedirect("/error");
+        }else{
+            response.sendRedirect("/user/login");
+        }
     }
 }

--- a/src/main/java/com/dalcho/adme/config/security/SecurityConfig.java
+++ b/src/main/java/com/dalcho/adme/config/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.dalcho.adme.config.security;
 
+import com.dalcho.adme.model.UserRole;
 import com.dalcho.adme.oauth2.CustomOAuthService;
 import com.dalcho.adme.oauth2.OAuth2SuccessHandler;
 import com.dalcho.adme.oauth2.Oauth2FailureHandler;
@@ -59,10 +60,10 @@ public class SecurityConfig {
 //					.exceptionHandling().authenticationEntryPoint(new RestAuthenticationEntryPoint())// 인증,인가가 되지 않은 요청 시 발생
 //					.and()
         http.authorizeHttpRequests()
+                .requestMatchers("/admin").hasAuthority(UserRole.ADMIN.name())
                 .requestMatchers(VIEW_LIST).permitAll()
                 .requestMatchers("/sign-up").permitAll()
                 .requestMatchers("/sign-in").permitAll()
-                .requestMatchers("/admin").hasAuthority("ADMIN")
                 .anyRequest().authenticated();
 
         http.formLogin()
@@ -81,7 +82,7 @@ public class SecurityConfig {
                     .failureHandler(failureHandler)
                 .and()
                     .exceptionHandling()
-                    //.accessDeniedHandler(new CustomAccessDeniedHandler())
+                    .accessDeniedHandler(new CustomAccessDeniedHandler())
                     .authenticationEntryPoint(customAuthenticationEntryPoint)
                 .and()
                     .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/dalcho/adme/config/security/SecurityConfig.java
+++ b/src/main/java/com/dalcho/adme/config/security/SecurityConfig.java
@@ -28,32 +28,21 @@ public class SecurityConfig {
     private final Oauth2FailureHandler failureHandler;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     public static final String[] VIEW_LIST = {
-            "/static/**",
-            "/css/**",
-            "/js/**",
             "/favicon.ico/**",
-            "/user/**",
+            "/adme",
             "/taste",
-            "/sign-up",
             "/ws/**",
             "/oauth2/**",
             "/alarm/**",
-            "/coco/**",
-             "/fonts/**",  "/webjars/**", "/templates/**","/**"
+            "/webjars/**", "/templates/**"
     };
-//    @Bean
-//    public WebSecurityCustomizer webSecurityCustomizer() {
-//        return (web) -> web.ignoring().requestMatchers("/js/**", "/css/**", "/static/**", "/fonts/**", "/favicon.ico");
-//    }
 
 	@Bean
 	public WebSecurityCustomizer webSecurityCustomizer() {
 		return web -> {
 			web.ignoring()
 					.requestMatchers(
-					"/sign-up", "/sign-in",
-							 "/css/**","/fonts/**", "/js/**","/webjars/**","/templates/**",
-                            "/adme"
+							 "/css/**","/fonts/**", "/js/**","/webjars/**","/user/**","/error"
 					);
 		};
 	}
@@ -73,26 +62,29 @@ public class SecurityConfig {
                 .requestMatchers(VIEW_LIST).permitAll()
                 .requestMatchers("/sign-up").permitAll()
                 .requestMatchers("/sign-in").permitAll()
-                .requestMatchers("/admin/**").hasAuthority("ADMIN")
+                .requestMatchers("/admin").hasAuthority("ADMIN")
                 .anyRequest().authenticated();
 
         http.formLogin()
                 .loginPage("/user/login")
-                .defaultSuccessUrl("/adme").and()
-                .logout()
-                .logoutUrl("/user/logout") // 로그아웃 처리 URL
-                .logoutSuccessUrl("/user/login");
-
-        http.oauth2Login().loginPage("/user/login")
-                .and().logout().logoutSuccessUrl("/taste");
-        http.oauth2Login().userInfoEndpoint().userService(customOAuth2UserService)
+                .defaultSuccessUrl("/adme")
                 .and()
-                .successHandler(successHandler)
-                .failureHandler(failureHandler);
-        http.exceptionHandling()
-                .authenticationEntryPoint(customAuthenticationEntryPoint)
+                    .logout()
+                    .logoutUrl("/user/logout") // 로그아웃 처리 URL
+                    .logoutSuccessUrl("/user/login")
                 .and()
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+                    .oauth2Login()
+                    .loginPage("/user/login")
+                    .userInfoEndpoint().userService(customOAuth2UserService)
+                .and()
+                    .successHandler(successHandler)
+                    .failureHandler(failureHandler)
+                .and()
+                    .exceptionHandling()
+                    //.accessDeniedHandler(new CustomAccessDeniedHandler())
+                    .authenticationEntryPoint(customAuthenticationEntryPoint)
+                .and()
+                    .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 


### PR DESCRIPTION
인가문제는 back, front 분리를 하지 않아서 완전히 해결되었다고 볼 수 없음
back, front 분리 해야 인가문제를 해결할 수 있음

*html도 token을 검증하면서 생긴 문제로 
로그인 후 관리자 페이지로 권한이 없는 사용자가 접속 시, 인가 오류가 떠야하지만
인가 대신 인증 오류로 떠서 html의 인증 상황에서 인가 오류로 보낼 시 관리자 또한 인가 오류로 뜨게 됨
따라서 단순히 log만 출력시키고 해당 페이지는 아무것도 안뜨게함.
관리자도 사용 불가함
